### PR TITLE
Fix: error if no valid camera found on load project

### DIFF
--- a/src/mayaMVG/core/MVGCamera.cpp
+++ b/src/mayaMVG/core/MVGCamera.cpp
@@ -43,7 +43,7 @@ MVGCamera::MVGCamera(const int& id)
 		status = MDagPath::getAPathTo(fn.object(), path);
 		CHECK_RETURN(status)
 		MVGCamera camera(path);
-		if(camera.isValid() && (camera.getId()==id)) {
+		if(camera.isValid() && (camera.getId() == id)) {
 			status = MDagPath::getAPathTo(fn.object(), _dagpath);
 			return;
 		}
@@ -125,7 +125,7 @@ MVGCamera MVGCamera::create(const std::string& name)
 }
 
 // static
-std::vector<MVGCamera> MVGCamera::list()
+std::vector<MVGCamera> MVGCamera::getCameras()
 {
 	std::vector<MVGCamera> list;
 	MDagPath path;

--- a/src/mayaMVG/core/MVGCamera.h
+++ b/src/mayaMVG/core/MVGCamera.h
@@ -28,7 +28,7 @@ class MVGCamera : public MVGNodeWrapper {
 
 	public:
 		static MVGCamera create(const std::string& name);
-		static std::vector<MVGCamera> list();
+		static std::vector<MVGCamera> getCameras();
 
 	public:
 		int getId() const;

--- a/src/mayaMVG/core/MVGProject.cpp
+++ b/src/mayaMVG/core/MVGProject.cpp
@@ -62,7 +62,7 @@ MVGProject::~MVGProject()
 // virtual
 bool MVGProject::isValid() const
 {
-	if(!_dagpath.isValid() || (_dagpath.apiType()!=MFn::kTransform))
+	if(!_dagpath.isValid() || (_dagpath.apiType() != MFn::kTransform))
 		return false;
 	MFnTransform fn(_dagpath);
 	MStatus status;
@@ -231,12 +231,6 @@ bool MVGProject::isProjectDirectoryValid(const std::string& projectDirectoryPath
 	}
 	
 	return true;
-}
-
-std::vector<MVGCamera> MVGProject::getCameras() const
-{
-	// TODO return cameras of this project
-	return MVGCamera::list();
 }
 
 void MVGProject::selectCameras(std::vector<std::string> cameraNames) const

--- a/src/mayaMVG/core/MVGProject.h
+++ b/src/mayaMVG/core/MVGProject.h
@@ -34,7 +34,6 @@ class MVGProject : public MVGNodeWrapper {
 		void setProjectDirectory(const std::string&) const;
         bool isProjectDirectoryValid(const std::string&) const;
 		// nodes
-		std::vector<MVGCamera> getCameras() const;
         void selectCameras(std::vector<std::string> cameraNames) const;
 
 	public:

--- a/src/mayaMVG/io/pointCloudIO.h
+++ b/src/mayaMVG/io/pointCloudIO.h
@@ -23,9 +23,14 @@ bool readPointCloud(std::string filePath)
 	}
 
 	// camera list
-	std::vector<MVGCamera> cameraList = MVGCamera::list();
+	std::vector<MVGCamera> cameraList = MVGCamera::getCameras();
+	if(cameraList.empty())
+	{
+		LOG_ERROR("No valid camera found")
+		return false;
+	}
 	std::sort(cameraList.begin(), cameraList.end()); // sort by camera id
-	
+
 	// items per camera tmp list
 	std::vector<std::vector<MVGPointCloudItem> > itemsPerCam(cameraList.size());
 

--- a/src/mayaMVG/qt/MVGProjectWrapper.cpp
+++ b/src/mayaMVG/qt/MVGProjectWrapper.cpp
@@ -143,6 +143,35 @@ void MVGProjectWrapper::clear() {
 	Q_EMIT projectDirectoryChanged();
 }
 
+void MVGProjectWrapper::removeCameraFromUI(MDagPath& cameraPath)
+{
+	MVGCamera camera(cameraPath);
+	if(!camera.isValid())
+		return;
+	
+	for(int i = 0; i < _cameraList.count(); ++i)
+	{
+		MVGCameraWrapper* cameraWrapper = static_cast<MVGCameraWrapper*>(_cameraList.at(i));
+		if(!cameraWrapper)
+			continue;		
+		if(cameraWrapper->getCamera().getName() != camera.getName())
+			continue;	
+		
+		MDagPath leftCameraPath, rightCameraPath;
+		MVGMayaUtil::getCameraInView(leftCameraPath, "mvgLPanel");
+		leftCameraPath.extendToShape();
+		if(leftCameraPath.fullPathName() == cameraPath.fullPathName())
+			MVGMayaUtil::clearCameraInView("mvgLPanel");
+		MVGMayaUtil::getCameraInView(rightCameraPath, "mvgRPanel");	
+		rightCameraPath.extendToShape();
+		if(rightCameraPath.fullPathName() == cameraPath.fullPathName())
+			MVGMayaUtil::clearCameraInView("mvgRPanel");
+
+		// Remove cameraWrapper
+		_cameraList.removeAt(i);
+	}
+}
+
 void MVGProjectWrapper::reloadMVGCamerasFromMaya()
 {
 	_cameraList.clear();
@@ -152,7 +181,7 @@ void MVGProjectWrapper::reloadMVGCamerasFromMaya()
 		return;
 	}
 	Q_EMIT projectDirectoryChanged();
-	const std::vector<MVGCamera>& cameraList = _project.getCameras();
+	const std::vector<MVGCamera>& cameraList = MVGCamera::getCameras();
 	std::vector<MVGCamera>::const_iterator it = cameraList.begin();
 	for(; it != cameraList.end(); ++it)
 		_cameraList.append(new MVGCameraWrapper(*it));

--- a/src/mayaMVG/qt/MVGProjectWrapper.h
+++ b/src/mayaMVG/qt/MVGProjectWrapper.h
@@ -46,6 +46,7 @@ public:
 	Q_INVOKABLE void loadNewProject(const QString& projectDirectoryPath);
 	Q_INVOKABLE void setCameraToView(QObject* camera, const QString& viewName, bool rebuildCache=true) const;
 	void clear();
+	void removeCameraFromUI(MDagPath& cameraPath);
 
 private:
 	void reloadMVGCamerasFromMaya();


### PR DESCRIPTION
- Check if the camera list is not empty on loading pointCloud
- Create a removeCameraFromUI function in MVGProjectWrapper
- Rename MVGCamera::list() to MVGCamera::getCameras()
