### PR TITLE
Camera selection from Maya

### DIFF
--- a/src/mayaMVG/core/MVGCamera.cpp
+++ b/src/mayaMVG/core/MVGCamera.cpp
@@ -241,25 +241,23 @@ void MVGCamera::loadImagePlane() const
     CHECK_RETURN(status)
     MPlug imageNamePlug = fnImage.findPlug("imageName", &status);
     CHECK_RETURN(status)
-    MString name = imageNamePlug.asString();
-    if(name != deferred)
-    {
-        status = imageNamePlug.setValue(deferred);
-        CHECK_RETURN(status)
-    }
+
+    MString cmd;
+    cmd.format("setAttr \"^1s\" -type \"string\" \"^2s\"", imageNamePlug.name(), deferred);
+    status = MGlobal::executeCommandOnIdle(cmd);
+    CHECK_RETURN(status)
 }
 
 void MVGCamera::unloadImagePlane() const
 {
     MStatus status;
-    MFnDagNode fnImage(getImagePath(), &status);
-    CHECK_RETURN(status)
+    MFnDagNode fnImage(getImagePath());
     MPlug imageNamePlug = fnImage.findPlug("imageName", &status);
     CHECK_RETURN(status)
-    MString name = imageNamePlug.asString();
-    if(name.length() == 0)
-        return;
-    status = imageNamePlug.setValue("");
+
+    MString cmd;
+    cmd.format("setAttr \"^1s\" -type \"string\" \"\"", imageNamePlug.name());
+    status = MGlobal::executeCommandOnIdle(cmd);
     CHECK_RETURN(status)
 }
 

--- a/src/mayaMVG/maya/MVGMayaCallbacks.hpp
+++ b/src/mayaMVG/maya/MVGMayaCallbacks.hpp
@@ -25,28 +25,37 @@ MVGProjectWrapper* getProjectWrapper()
 
 } // empty namespace
 
-// static void selectionChangedCB(void*)
-//{
-//    MVGProjectWrapper* project = getProjectWrapper();
-//    if(!project)
-//        return;
-//    MSelectionList list;
-//    MGlobal::getActiveSelectionList(list);
-//    MDagPath path;
-//    QList<QString> selectedCameras;
-//    for(size_t i = 0; i < list.length(); i++)
-//    {
-//        list.getDagPath(i, path);
-//        path.extendToShape();
-//        if(path.isValid() &&
-//           ((path.child(0).apiType() == MFn::kCamera) || (path.apiType() == MFn::kCamera)))
-//        {
-//            MFnDependencyNode fn(path.transform());
-//            selectedCameras.push_back(fn.name().asChar());
-//        }
-//    }
-//    project->selectItems(selectedCameras);
-//}
+static void selectionChangedCB(void*)
+{
+    MVGProjectWrapper* project = getProjectWrapper();
+    if(!project)
+        return;
+    MSelectionList list;
+    MGlobal::getActiveSelectionList(list);
+    MDagPath path;
+    QStringList selectedCameras;
+    for(size_t i = 0; i < list.length(); i++)
+    {
+        list.getDagPath(i, path);
+        path.extendToShape();
+        if(path.isValid() &&
+           ((path.child(0).apiType() == MFn::kCamera) || (path.apiType() == MFn::kCamera)))
+        {
+            MFnDependencyNode fn(path.transform());
+            selectedCameras.push_back(fn.name().asChar());
+        }
+    }
+
+    if(selectedCameras.size() == 0)
+        return;
+
+    // Compare IHM selection to Maya selection
+    QStringList IHMSelectedCamera = project->getSelectedCameras();
+    IHMSelectedCamera.sort();
+    selectedCameras.sort();
+    if(IHMSelectedCamera != selectedCameras)
+        project->addCamerasToIHMSelection(selectedCameras, true);
+}
 
 static void currentContextChangedCB(void*)
 {

--- a/src/mayaMVG/maya/plugin.cpp
+++ b/src/mayaMVG/maya/plugin.cpp
@@ -71,6 +71,9 @@ MStatus initializePlugin(MObject obj)
     MEventMessage::addEventCallback("Redo", redoCB, &status);
     if(status)
         _callbacks.append(id);
+    MEventMessage::addEventCallback("SelectionChanged", selectionChangedCB, &status);
+    if(status)
+        _callbacks.append(id);
     MEventMessage::addEventCallback("modelEditorChanged", modelEditorChangedCB, &status);
     if(status)
         _callbacks.append(id);

--- a/src/mayaMVG/qt/MVGCameraWrapper.hpp
+++ b/src/mayaMVG/qt/MVGCameraWrapper.hpp
@@ -30,6 +30,8 @@ public slots:
     bool isSelected() const { return _isSelected; }
     void setIsSelected(const bool isSelected)
     {
+        if(_isSelected == isSelected)
+            return;
         _isSelected = isSelected;
         Q_EMIT isSelectedChanged();
     }

--- a/src/mayaMVG/qt/MVGProjectWrapper.cpp
+++ b/src/mayaMVG/qt/MVGProjectWrapper.cpp
@@ -131,13 +131,37 @@ void MVGProjectWrapper::loadNewProject(const QString& projectDirectoryPath)
     }
 }
 
-void MVGProjectWrapper::selectItems(const QStringList& cameraNames) const
+void MVGProjectWrapper::addCamerasToIHMSelection(const QStringList& selectedCameraNames,
+                                                 bool center)
 {
-    foreach(MVGCameraWrapper* camera, _cameraList.asQList<MVGCameraWrapper>())
-        camera->setIsSelected(cameraNames.contains(camera->getName()));
+    // Reset old selection to false
+    for(QStringList::const_iterator it = _selectedCameras.begin(); it != _selectedCameras.end();
+        ++it)
+    {
+        MVGCameraWrapper* camera = _camerasByName[it->toStdString()];
+        camera->setIsSelected(false);
+    }
+    _selectedCameras.clear();
+    // Set new selection to true
+    for(QStringList::const_iterator it = selectedCameraNames.begin();
+        it != selectedCameraNames.end(); ++it)
+    {
+        if(_camerasByName.count(it->toStdString()) == 0)
+            continue;
+        MVGCameraWrapper* camera = _camerasByName[it->toStdString()];
+        camera->setIsSelected(true);
+        _selectedCameras.append(camera->getName());
+        // Replace listView and set image in first viewort
+        // TODO : let the user define in which viewport he wants to display the selected camera
+        if(center && camera->getName() == selectedCameraNames[0])
+        {
+            setCameraToView(camera, static_cast<MVGPanelWrapper*>(_panelList.get(0))->getName());
+            Q_EMIT centerCameraListByIndex(_cameraList.indexOf(camera));
+        }
+    }
 }
 
-void MVGProjectWrapper::selectCameras(const QStringList& cameraNames) const
+void MVGProjectWrapper::addCamerasToMayaSelection(const QStringList& cameraNames) const
 {
     if(!_project.isValid())
         return;

--- a/src/mayaMVG/qt/MVGProjectWrapper.hpp
+++ b/src/mayaMVG/qt/MVGProjectWrapper.hpp
@@ -30,6 +30,7 @@ public slots:
     const QString getProjectDirectory() const;
     void setProjectDirectory(const QString& directory);
     QObjectListModel* getCameraModel() { return &_cameraList; }
+    QStringList& getSelectedCameras() { return _selectedCameras; }
     QObjectListModel* getPanelList() { return &_panelList; }
     const QString getCurrentContext() const;
     void setCurrentContext(const QString&);
@@ -43,10 +44,11 @@ signals:
     void panelListChanged();
     void currentUnitChanged();
     void unitModelChanged();
+    void centerCameraListByIndex(const int cameraIndex);
 
 public:
-    Q_INVOKABLE void selectItems(const QStringList& cameraNames) const;
-    Q_INVOKABLE void selectCameras(const QStringList& cameraNames) const;
+    Q_INVOKABLE void addCamerasToIHMSelection(const QStringList& cameraNames, bool center = false);
+    Q_INVOKABLE void addCamerasToMayaSelection(const QStringList& cameraNames) const;
     Q_INVOKABLE QString openFileDialog() const;
     Q_INVOKABLE void activeSelectionContext() const;
     Q_INVOKABLE void activeMVGContext();
@@ -67,6 +69,9 @@ private:
 
 private:
     QObjectListModel _cameraList;
+    /// Names of the selected cameras
+    /// Selection already stored in camera but this list is needed for a faster access
+    QStringList _selectedCameras;
     MVGProject _project;
     QObjectListModel _panelList;
     QString _currentContext;

--- a/src/mayaMVG/qt/qml/CameraList.qml
+++ b/src/mayaMVG/qt/qml/CameraList.qml
@@ -26,8 +26,8 @@ Item {
         {
             qlist[qlist.length] = m.project.cameraModel.get(i).name;
         }
-        m.project.selectItems(qlist)
-        m.project.selectCameras(qlist);
+        m.project.addCamerasToIHMSelection(qlist);
+        m.project.addCamerasToMayaSelection(qlist);
     }
     function computeListPosition(keyValue, upLimit, downLimit, currentPosition, step)
     {
@@ -39,6 +39,11 @@ Item {
                 return (currentPosition + step < downLimit) ? currentPosition + step : downLimit
         }
     }
+
+    Connections {
+         target: _project
+         onCenterCameraListByIndex: cameraListView.contentY = cameraIndex * m.thumbSize
+     }
 
     RowLayout {
         anchors.fill: parent
@@ -59,7 +64,7 @@ Item {
                 project: m.project
                 onSelection: {
                     m.currentIndex = index
-                    selectCameras(index, index) //m.currentIndex = index
+                    selectCameras(index, index)
                 }
                 onMultipleSelection: selectCameras(m.currentIndex, index)
             }


### PR DESCRIPTION
Closes #48
After camera selection from Maya :
- camera is selected in MVG interface
- first selected camera is displayed in first MVGViewport
- camera list view begins at first selected camera item

Use MEL command to load image plane to avoid crashes (execute command on
idle)
