### PR TITLE
Fix: use "imageNameDeferred" in MVGImagePlaneCmd

### DIFF
--- a/src/mayaMVG/core/MVGCamera.hpp
+++ b/src/mayaMVG/core/MVGCamera.hpp
@@ -60,11 +60,13 @@ public:
 
     const std::pair<double, double> getImageSize() const;
 
+public:
+    static MString _DEFERRED;
+
 private:
     static MString _ID;
     static MString _PINHOLE;
     static MString _ITEMS;
-    static MString _DEFERRED;
 };
 
 } // namespace

--- a/src/mayaMVG/maya/cmd/MVGImagePlaneCmd.cpp
+++ b/src/mayaMVG/maya/cmd/MVGImagePlaneCmd.cpp
@@ -1,5 +1,6 @@
 #include "MVGImagePlaneCmd.hpp"
 #include "mayaMVG/core/MVGProject.hpp"
+#include "mayaMVG/core/MVGCamera.hpp"
 #include "mayaMVG/core/MVGLog.hpp"
 #include <maya/MSyntax.h>
 #include <maya/MArgDatabase.h>
@@ -90,7 +91,7 @@ MStatus MVGImagePlaneCmd::doIt(const MArgList& args)
         imageNamePlug.getValue(imageNameValue);
 
         // Set "deferred" attribute into "imageName" attribute
-        MString deferred = fnImagePlane.findPlug("deferredLoading", &status).asString();
+        MString deferred = fnImagePlane.findPlug(MVGCamera::_DEFERRED, &status).asString();
         CHECK_RETURN_STATUS(status)
         if(imageNameValue != deferred)
         {


### PR DESCRIPTION
Find "imageNameDeferred" attribute instead of "deferredLoading" in
MVGImagePlaneCmd.
See commit : Add: "Export selection as ABC" item in MayaMVG menu
(84063482c756db2a9a7b76f04bfc31d27c4b1746)
