### PR TITLE
Fix shortcuts in Maya 2016 + Add shortcut for selecting the closest camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 *.py[cod]
 
 # Distribution & packaging
-build/
+/build*/
 lib/
 bin/
 dist/

--- a/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.cpp
+++ b/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.cpp
@@ -1,0 +1,47 @@
+#include "MVGSelectClosestCamCmd.hpp"
+#include "mayaMVG/core/MVGProject.hpp"
+#include "mayaMVG/core/MVGCamera.hpp"
+#include "mayaMVG/maya/MVGMayaUtil.hpp"
+#include <maya/MMatrix.h>
+
+
+namespace mayaMVG
+{   
+
+MString MVGSelectClosestCamCmd::_name("MVGSelectClosestCamCmd");
+
+void* MVGSelectClosestCamCmd::creator() 
+{
+    return new MVGSelectClosestCamCmd();
+}
+
+MStatus MVGSelectClosestCamCmd::doIt(const MArgList& args)
+{
+    // Retrieve perspective matrix
+    MDagPath perspDagPath;
+    MVGMayaUtil::getDagPathByName("perspShape", perspDagPath);
+
+    // Browse all MVG cameras
+    std::multimap<float, std::string> camMap;
+    std::vector<MVGCamera> mvgCameras = MVGCamera::getCameras();
+    for(std::vector<MVGCamera>::iterator it = mvgCameras.begin(); it != mvgCameras.end(); ++it)
+    {
+        // Compute Frobenius norm
+        MDagPath camDagPath = it->getDagPath();
+        MMatrix matrix = perspDagPath.inclusiveMatrix() - camDagPath.inclusiveMatrix();
+        float norm = 0;
+        for(size_t i = 0; i < 4; ++i)
+            for(size_t j = 0; j < 4; ++j)
+                norm += std::pow(matrix[i][j], 2.0);
+        camMap.insert(std::make_pair(norm, camDagPath.partialPathName().asChar()));
+    }
+    if(!camMap.empty())
+    {
+        MVGProject project(MVGProject::_PROJECT);
+        std::vector<std::string> cams(1, camMap.begin()->second);
+        project.selectCameras(cams);
+    }
+    return MS::kSuccess;
+}
+
+}

--- a/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.hpp
+++ b/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <maya/MPxCommand.h>
+
+namespace mayaMVG
+{
+
+class MVGSelectClosestCamCmd : public MPxCommand
+{
+
+public:
+    MVGSelectClosestCamCmd(){};
+
+    static void* creator();
+    virtual MStatus doIt(const MArgList& args);
+
+public:
+    static MString _name;
+
+};
+
+}

--- a/src/mayaMVG/maya/plugin.cpp
+++ b/src/mayaMVG/maya/plugin.cpp
@@ -5,6 +5,7 @@
 #include "mayaMVG/maya/cmd/MVGCmd.hpp"
 #include "mayaMVG/maya/cmd/MVGEditCmd.hpp"
 #include "mayaMVG/maya/cmd/MVGImagePlaneCmd.hpp"
+#include "mayaMVG/maya/cmd/MVGSelectClosestCamCmd.hpp"
 #include "mayaMVG/maya/context/MVGContextCmd.hpp"
 #include "mayaMVG/maya/context/MVGCreateManipulator.hpp"
 #include "mayaMVG/maya/context/MVGMoveManipulator.hpp"
@@ -123,6 +124,7 @@ MStatus initializePlugin(MObject obj)
     CHECK(plugin.registerCommand("MVGCmd", MVGCmd::creator))
     CHECK(plugin.registerCommand("MVGImagePlaneCmd", MVGImagePlaneCmd::creator,
                                  MVGImagePlaneCmd::newSyntax))
+    CHECK(plugin.registerCommand(MVGSelectClosestCamCmd::_name, MVGSelectClosestCamCmd::creator))
     CHECK(plugin.registerContextCommand(MVGContextCmd::name, &MVGContextCmd::creator,
                                         MVGEditCmd::_name, MVGEditCmd::creator,
                                         MVGEditCmd::newSyntax))
@@ -223,6 +225,7 @@ MStatus uninitializePlugin(MObject obj)
 
     // Deregister Maya context, commands & nodes
     CHECK(plugin.deregisterCommand("MVGCmd"))
+    CHECK(plugin.deregisterCommand("MVGSelectClosestCamCmd"))
     CHECK(plugin.deregisterCommand("MVGImagePlaneCmd"))
     CHECK(plugin.deregisterContextCommand(MVGContextCmd::name, MVGEditCmd::_name))
     CHECK(plugin.deregisterNode(MVGCreateManipulator::_id))

--- a/src/mayaMVG/maya/plugin.cpp
+++ b/src/mayaMVG/maya/plugin.cpp
@@ -96,6 +96,16 @@ MStatus registerMVGHotkeys()
     status = MGlobal::executePythonCommand(cmd);
     CHECK_RETURN_STATUS(status)
     _commands.append(commandName);
+    
+    // MVGSelectClosestCamCommand
+    commandName = "MVGSelectClosestCamCommand";
+    cmd.format("^1s", MVGSelectClosestCamCmd::_name);
+    keySequence = "F";
+    cmd.format("context.initMVGCommand(\"^1s\", \"^2s\", \"mel\", \"^3s\", False, True)",
+               commandName, cmd, keySequence);
+    status = MGlobal::executePythonCommand(cmd);
+    CHECK_RETURN_STATUS(status)
+    _commands.append(commandName);
 
     return status;
 }

--- a/src/mayaMVG/maya/plugin.cpp
+++ b/src/mayaMVG/maya/plugin.cpp
@@ -45,6 +45,10 @@ MStatus registerMVGHotkeys()
     MString moveModeString;
 
     MGlobal::executePythonCommand("from mayaMVG import context");
+    
+    // Use or create a writable hotkey set
+    MGlobal::executePythonCommand("context.initHotkeySet()");
+
     // MVGCreateCommand
     commandName = "MVGCreateCommand";
     editModeString = MVGContext::eEditModeCreate;

--- a/src/mayaMVG/maya/scripts/mayaMVG/context.py
+++ b/src/mayaMVG/maya/scripts/mayaMVG/context.py
@@ -16,6 +16,19 @@ def mvgCreateContext():
         cmds.deleteUI('mayaMVGTool1', toolContext=True)
     cmds.mayaMVGTool('mayaMVGTool1')
 
+def initHotkeySet():
+    """ For Maya >=2016, ensure the current hotkey set is writable. """
+    if cmds.about(version=True) < "2016":
+        return
+    currentSet = cmds.hotkeySet(current=True, q=True)
+    if currentSet == "Maya_Default":  # Read-only set
+        writableSetName = "Maya_Default_MVG"
+        # Select or create writable hotkey set
+        if cmds.hotkeySet(writableSetName, exists=True):
+            cmds.hotkeySet(writableSetName, current=True, edit=True)
+        else:
+            cmds.hotkeySet(writableSetName, current=True)
+
 # source_type = "mel" or "python"
 def initMVGCommand(name, script, source_type, key_sequence, alt=False, ctl=False, command=False, release=False):
     # Runtime command

--- a/src/mayaMVG/qt/MVGMainWidget.cpp
+++ b/src/mayaMVG/qt/MVGMainWidget.cpp
@@ -22,10 +22,6 @@ MVGMainWidget::MVGMainWidget(QWidget* parent)
 
     _projectWrapper.loadExistingProject();
     QString importDirectory = QString(MVGMayaUtil::getModulePath().asChar()) + "/qml";
-    const char* devQmlPath = std::getenv("MAYAMVG_QML_PATH");
-    QString sourceDirectory = importDirectory + "/mvg/main.qml";
-    if(devQmlPath)
-        sourceDirectory = "./src/mayaMVG/qt/qml/main.qml";
 
     // QtDesktop Components
     _view->engine()->addPluginPath(importDirectory);
@@ -35,15 +31,19 @@ MVGMainWidget::MVGMainWidget(QWidget* parent)
     _view->rootContext()->setContextProperty("_project", &_projectWrapper);
 
     // Qml source
-    _view->setSource(QUrl::fromLocalFile(sourceDirectory));
-    _view->setResizeMode(QDeclarativeView::SizeRootObjectToView);
-
-    // Instant coding
+    const char* devQmlPath = std::getenv("MAYAMVG_QML_PATH");
+    QString mainQml = importDirectory + "/mvg/main.qml";
     if(devQmlPath)
     {
+        QDir qmlFolder = QFileInfo(__FILE__).dir();
+        qmlFolder.cd("qml");
+        mainQml = QFileInfo(qmlFolder, "main.qml").absoluteFilePath();
+        
         QmlInstantCoding* qic = new QmlInstantCoding(_view, true);
-        qic->addFilesFromDirectory(devQmlPath, true);
+        qic->addFilesFromDirectory(qmlFolder.absolutePath(), true);
     }
+    _view->setSource(QUrl::fromLocalFile(mainQml));
+    _view->setResizeMode(QDeclarativeView::SizeRootObjectToView);
 }
 
 MVGMainWidget::~MVGMainWidget()

--- a/src/mayaMVG/qt/MVGMainWidget.cpp
+++ b/src/mayaMVG/qt/MVGMainWidget.cpp
@@ -31,9 +31,9 @@ MVGMainWidget::MVGMainWidget(QWidget* parent)
     _view->rootContext()->setContextProperty("_project", &_projectWrapper);
 
     // Qml source
-    const char* devQmlPath = std::getenv("MAYAMVG_QML_PATH");
+    const char* instantCoding = std::getenv("MAYAMVG_USE_QMLINSTANTCODING");
     QString mainQml = importDirectory + "/mvg/main.qml";
-    if(devQmlPath)
+    if(instantCoding)
     {
         QDir qmlFolder = QFileInfo(__FILE__).dir();
         qmlFolder.cd("qml");

--- a/src/mayaMVG/qt/MVGProjectWrapper.cpp
+++ b/src/mayaMVG/qt/MVGProjectWrapper.cpp
@@ -9,6 +9,7 @@
 #include "mayaMVG/maya/context/MVGContext.hpp"
 #include "mayaMVG/maya/context/MVGMoveManipulator.hpp"
 #include "mayaMVG/maya/MVGDummyLocator.h"
+#include "mayaMVG/maya/cmd/MVGSelectClosestCamCmd.hpp"
 #include <maya/MQtUtil.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MFnTransform.h>
@@ -362,33 +363,7 @@ void MVGProjectWrapper::addMeshesToMayaSelection(const QStringList& meshesPath) 
 
 void MVGProjectWrapper::selectClosestCam() const
 {
-
-    // Retrieve perspective matrix
-    MDagPath perspDagPath;
-    MVGMayaUtil::getDagPathByName("perspShape", perspDagPath);
-
-    // Browse all MVG cameras
-    std::multimap<float, MString> camMap;
-    std::vector<MVGCamera> mvgCameras = MVGCamera::getCameras();
-    for(std::vector<MVGCamera>::iterator it = mvgCameras.begin(); it != mvgCameras.end(); ++it)
-    {
-        // Compute Frobenius norm
-        MDagPath camDagPath = it->getDagPath();
-        MMatrix matrix = perspDagPath.inclusiveMatrix() - camDagPath.inclusiveMatrix();
-        float norm = 0;
-        for(size_t i = 0; i < 4; ++i)
-            for(size_t j = 0; j < 4; ++j)
-                norm += std::pow(matrix[i][j], 2.0);
-        camMap.insert(std::make_pair(norm, camDagPath.partialPathName()));
-    }
-
-    // Update selection
-    if(!camMap.empty())
-    {
-        QStringList cameraList;
-        cameraList.append(MQtUtil::toQString(camMap.begin()->second));
-        addCamerasToMayaSelection(cameraList);
-    }
+    MGlobal::executeCommand(MVGSelectClosestCamCmd::_name);
 }
 
 void MVGProjectWrapper::setCameraToView(QObject* camera, const QString& viewName)

--- a/src/mayaMVG/qt/QmlInstantCoding.cpp
+++ b/src/mayaMVG/qt/QmlInstantCoding.cpp
@@ -1,6 +1,7 @@
 #include "mayaMVG/qt/QmlInstantCoding.hpp"
 #include "mayaMVG/core/MVGLog.hpp"
 #include <QDir>
+#include <unistd.h> 
 
 namespace mayaMVG
 {


### PR DESCRIPTION
Connected to #175
- Fix hotkeys (shorcuts) : Maya 2016 uses a new hotkey system. The one by default is read-only, so we select a writable one to assign our shortcuts or create a new one if needed.
- Added a shortcut to select the closest camera (Ctrl+F by default)
- Fixed QmlInstantCoding; just have to define MAYAMVG_QML_PATH=1 in the environment
