### PR TITLE
Enable C++11 and set OpenMVG as an external dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,12 @@
 
 cmake_minimum_required(VERSION 2.6.2)
-project(openMVG-UI)
-
+project(mayaMVG)
 
 #
 # Compiler settings
 #
 if(UNIX)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
 endif()
 
 #
@@ -20,5 +18,4 @@ set(CMAKE_MODULE_PATH "${MAINFOLDER}/cmake")
 #
 # Add Build Targets
 #
-add_subdirectory(openMVG/src EXCLUDE_FROM_ALL)
 add_subdirectory(mayaMVG)

--- a/src/mayaMVG/CMakeLists.txt
+++ b/src/mayaMVG/CMakeLists.txt
@@ -21,8 +21,6 @@ include_directories(${PROJECT_SOURCE_DIR}/..)
 # Maya dependency
 #
 find_package(Maya REQUIRED)
-include_directories(${MAYA_INCLUDE_DIR})
-link_directories(${MAYA_Foundation_LIBRARY} ${MAYA_OpenMaya_LIBRARY} ${MAYA_OpenMayaUI_LIBRARY} ${MAYA_OpenMayaFX_LIBRARY})
 
 #
 # Qt dependency
@@ -35,15 +33,13 @@ include(${QT_USE_FILE})
 #
 # OpenMVG dependency
 #
-include_directories(
-			../openMVG/src
-			../openMVG/src/third_party/eigen)
+find_package(OpenMVG REQUIRED)
+find_package(Ceres REQUIRED)
 
 #
 # OpenGL dependency
 #
 find_package(OpenGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIR})
 
 #
 # Plugin name
@@ -76,20 +72,26 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # Maya plugin properties
 #
 add_library(${project_BIN} SHARED
-				${PLUGIN_SRCS}
-				${MOC_SRCS})
-target_link_libraries(
-				${project_BIN}
-				${MAYA_Foundation_LIBRARY}
-				${MAYA_OpenMaya_LIBRARY}
-				${MAYA_OpenMayaUI_LIBRARY}
-				${MAYA_OpenMayaFX_LIBRARY}
-				${MAYA_OpenMayaRender_LIBRARY}
-				stlplus
-				openMVG_numeric
-				openMVG_multiview
-				${QT_LIBRARIES}
-				${OPENGL_LIBRARIES})
+    ${PLUGIN_SRCS}
+    ${MOC_SRCS})
+target_include_directories(${project_BIN} PUBLIC
+    ${MAYA_INCLUDE_DIR}
+    ${OPENMVG_INCLUDE_DIRS}
+    ${OPENGL_INCLUDE_DIR}
+    )
+target_link_libraries(${project_BIN} PUBLIC
+    ${MAYA_Foundation_LIBRARY}
+    ${MAYA_OpenMaya_LIBRARY}
+    ${MAYA_OpenMayaUI_LIBRARY}
+    ${MAYA_OpenMayaFX_LIBRARY}
+    ${MAYA_OpenMayaRender_LIBRARY}
+    ${OPENMVG_LIBRARY}
+    stlplus
+    openMVG_numeric
+    openMVG_multiview
+    ${QT_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    )
 maya_set_plugin_properties(${project_BIN})
 
 #

--- a/src/mayaMVG/core/MVGCamera.hpp
+++ b/src/mayaMVG/core/MVGCamera.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#undef Success // needed by eigen
 #include "mayaMVG/core/MVGNodeWrapper.hpp"
-#include "openMVG/cameras/PinholeCamera.hpp"
 #include <vector>
 #include <map>
 

--- a/src/mayaMVG/core/MVGEigen.hpp
+++ b/src/mayaMVG/core/MVGEigen.hpp
@@ -1,0 +1,17 @@
+#pragma once
+// /!\ Include this file instead of <openMVG/numeric/numeric.h>
+// /!\ or before any include of OpenMVG or Eigen
+
+// X11 defines CamelCase macros that clash with some of Eigen's enums.
+// To avoid include-order based issues, we undefine those problematic names
+// see : http://eigen.tuxfamily.org/bz/show_bug.cgi?id=253
+#if defined(LINUX)
+
+#if defined(Success)
+#undef Success
+#endif
+
+#endif //LINUX
+
+// openMVG includes Eigen
+#include <openMVG/numeric/numeric.h>

--- a/src/mayaMVG/core/MVGGeometryUtil.cpp
+++ b/src/mayaMVG/core/MVGGeometryUtil.cpp
@@ -7,6 +7,8 @@
 #include "mayaMVG/core/MVGLineConstrainedPlaneKernel.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
 #include <openMVG/multiview/triangulation_nview.hpp>
+#include <openMVG/multiview/projection.hpp>
+#include <openMVG/robust_estimation/robust_estimator_LMeds.hpp>
 #include <maya/MPointArray.h>
 #include <maya/M3dView.h>
 #include <maya/MPlug.h>

--- a/src/mayaMVG/core/MVGGeometryUtil.hpp
+++ b/src/mayaMVG/core/MVGGeometryUtil.hpp
@@ -2,8 +2,11 @@
 
 #include "mayaMVG/core/MVGPlaneKernel.hpp"
 #include "mayaMVG/core/MVGLineConstrainedPlaneKernel.hpp"
+
 #include <maya/MVector.h>
+
 #include <map>
+
 
 class MPoint;
 class MPointArray;

--- a/src/mayaMVG/core/MVGLineConstrainedPlaneKernel.cpp
+++ b/src/mayaMVG/core/MVGLineConstrainedPlaneKernel.cpp
@@ -1,0 +1,45 @@
+#include "MVGLineConstrainedPlaneKernel.hpp"
+
+#include <openMVG/robust_estimation/robust_estimator_LMeds.hpp>
+
+namespace mayaMVG
+{
+
+LineConstrainedPlaneKernel::LineConstrainedPlaneKernel(const openMVG::Mat& pt, const openMVG::Vec3& constraintP0,
+                           const openMVG::Vec3& constraintP1)
+    : _pt(pt)
+    , _constraintP0(constraintP0)
+    , _constraintP1(constraintP1)
+    // Compute the segment values (in 3d) between p1 and p0
+    , _P1P0(_constraintP1 - _constraintP0)
+{
+}
+void LineConstrainedPlaneKernel::Fit(const std::vector<size_t>& samples, std::vector<Model>* equation) const
+{
+    assert(samples.size() >= MINIMUM_SAMPLES);
+    equation->clear();
+    openMVG::Mat sampled_xs = openMVG::ExtractColumns(_pt, samples);
+    openMVG::Vec3 p2 = sampled_xs.col(0);
+    // Compute the segment values (in 3d) between p2 and p0
+    const openMVG::Vec3 p2p0 = p2 - _constraintP0;
+    // Avoid some crashes by checking for collinearity here
+    openMVG::Vec3 dy1dy2 = _P1P0.array() / p2p0.array();
+    if((dy1dy2[0] == dy1dy2[1]) && (dy1dy2[2] == dy1dy2[1])) // Check for collinearity
+        return;
+    // Compute the plane coefficients from the 3 given points in a
+    // straightforward manner
+    // calculate the plane normal n = (p2-p1) x (p3-p1) = cross(p2-p1, p3-p1)
+    Model m;
+    m[0] = _P1P0[1] * p2p0[2] - _P1P0[2] * p2p0[1];
+    m[1] = _P1P0[2] * p2p0[0] - _P1P0[0] * p2p0[2];
+    m[2] = _P1P0[0] * p2p0[1] - _P1P0[1] * p2p0[0];
+    m[3] = 0.0;
+    m.normalize();
+    // [ n' d ] dot [ p0 ; 1 ])
+    // m[3] = -d with d the distance from the plane m, whose unit normal is n, to p0
+    //        m[3] = -1.0 * (m.head<3>().dot(p0));
+    m[3] = -1.0 * (m.head<3>().dot(_constraintP0));
+    equation->push_back(m);
+}
+
+} // namespace

--- a/src/mayaMVG/core/MVGPlaneKernel.cpp
+++ b/src/mayaMVG/core/MVGPlaneKernel.cpp
@@ -1,0 +1,39 @@
+#include "MVGPlaneKernel.hpp"
+
+#include <openMVG/robust_estimation/robust_estimator_LMeds.hpp>
+
+
+namespace mayaMVG
+{
+
+void PlaneKernel::Fit(const std::vector<size_t>& samples, std::vector<Model>* equation) const
+{
+    assert(samples.size() >= MINIMUM_SAMPLES);
+    equation->clear();
+    openMVG::Mat sampled_xs = openMVG::ExtractColumns(_pt, samples);
+    openMVG::Vec3 p0 = sampled_xs.col(0);
+    openMVG::Vec3 p1 = sampled_xs.col(1);
+    openMVG::Vec3 p2 = sampled_xs.col(2);
+    // Compute the segment values (in 3d) between p1 and p0
+    openMVG::Vec3 p1p0 = p1 - p0;
+    // Compute the segment values (in 3d) between p2 and p0
+    openMVG::Vec3 p2p0 = p2 - p0;
+    // Avoid some crashes by checking for collinearity here
+    openMVG::Vec3 dy1dy2 = p1p0.array() / p2p0.array();
+    if((dy1dy2[0] == dy1dy2[1]) && (dy1dy2[2] == dy1dy2[1])) // Check for collinearity
+        return;
+    // Compute the plane coefficients from the 3 given points in a
+    // straightforward manner
+    // calculate the plane normal n = (p2-p1) x (p3-p1) = cross(p2-p1, p3-p1)
+    Model m;
+    m[0] = p1p0[1] * p2p0[2] - p1p0[2] * p2p0[1];
+    m[1] = p1p0[2] * p2p0[0] - p1p0[0] * p2p0[2];
+    m[2] = p1p0[0] * p2p0[1] - p1p0[1] * p2p0[0];
+    m[3] = 0.0;
+    m.normalize();
+    m[3] = -1.0 * (m.head<3>().dot(p0));
+    equation->push_back(m);
+}
+
+
+} // namespace

--- a/src/mayaMVG/core/MVGPlaneKernel.hpp
+++ b/src/mayaMVG/core/MVGPlaneKernel.hpp
@@ -1,10 +1,9 @@
 #pragma once
-#include <maya/MPoint.h>
-#include <openMVG/numeric/numeric.h>
-#include <openMVG/robust_estimation/robust_estimator_LMeds.hpp>
 
-namespace mayaMVG
-{
+#include "MVGEigen.hpp"
+#include <maya/MPoint.h>
+
+namespace mayaMVG {
 
 // Should be part of OpenMVG
 struct PlaneKernel
@@ -19,35 +18,10 @@ struct PlaneKernel
     {
     }
     size_t NumSamples() const { return _pt.cols(); }
-    void Fit(const std::vector<size_t>& samples, std::vector<Model>* equation) const
-    {
-        assert(samples.size() >= MINIMUM_SAMPLES);
-        equation->clear();
-        openMVG::Mat sampled_xs = openMVG::ExtractColumns(_pt, samples);
-        openMVG::Vec3 p0 = sampled_xs.col(0);
-        openMVG::Vec3 p1 = sampled_xs.col(1);
-        openMVG::Vec3 p2 = sampled_xs.col(2);
-        // Compute the segment values (in 3d) between p1 and p0
-        openMVG::Vec3 p1p0 = p1 - p0;
-        // Compute the segment values (in 3d) between p2 and p0
-        openMVG::Vec3 p2p0 = p2 - p0;
-        // Avoid some crashes by checking for collinearity here
-        openMVG::Vec3 dy1dy2 = p1p0.array() / p2p0.array();
-        if((dy1dy2[0] == dy1dy2[1]) && (dy1dy2[2] == dy1dy2[1])) // Check for collinearity
-            return;
-        // Compute the plane coefficients from the 3 given points in a
-        // straightforward manner
-        // calculate the plane normal n = (p2-p1) x (p3-p1) = cross(p2-p1, p3-p1)
-        Model m;
-        m[0] = p1p0[1] * p2p0[2] - p1p0[2] * p2p0[1];
-        m[1] = p1p0[2] * p2p0[0] - p1p0[0] * p2p0[2];
-        m[2] = p1p0[0] * p2p0[1] - p1p0[1] * p2p0[0];
-        m[3] = 0.0;
-        m.normalize();
-        m[3] = -1.0 * (m.head<3>().dot(p0));
-        equation->push_back(m);
-    }
-    double Error(size_t sample, const Model& model) const
+    
+    void Fit(const std::vector<size_t>& samples, std::vector<Model>* equation) const;
+    
+    inline double Error(size_t sample, const Model& model) const
     {
         // Calculate the distance from the point to the plane normal as the dot
         // product
@@ -60,7 +34,7 @@ struct PlaneKernel
 };
 
 // FIXME check return value
-static bool plane_line_intersect(const PlaneKernel::Model& model, const MPoint& P1,
+inline bool plane_line_intersect(const PlaneKernel::Model& model, const MPoint& P1,
                                  const MPoint& P2, MPoint& P)
 {
     double u = (model(0) * P1.x + model(1) * P1.y + model(2) * P1.z + model(3)) /

--- a/src/mayaMVG/core/MVGProject.cpp
+++ b/src/mayaMVG/core/MVGProject.cpp
@@ -4,6 +4,7 @@
 #include "mayaMVG/core/MVGLog.hpp"
 #include "mayaMVG/maya/context/MVGContextCmd.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
+
 #include <maya/MFnTransform.h>
 #include <maya/MItDependencyNodes.h>
 #include <maya/MDagModifier.h>
@@ -15,6 +16,8 @@
 #include <maya/MMatrix.h>
 #include <maya/MItSelectionList.h>
 #include <maya/MItMeshPolygon.h>
+
+#include <algorithm>
 
 namespace
 { // empty namespace

--- a/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.cpp
+++ b/src/mayaMVG/maya/cmd/MVGSelectClosestCamCmd.cpp
@@ -2,7 +2,10 @@
 #include "mayaMVG/core/MVGProject.hpp"
 #include "mayaMVG/core/MVGCamera.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
+
 #include <maya/MMatrix.h>
+
+#include <cmath>
 
 
 namespace mayaMVG

--- a/src/mayaMVG/maya/context/MVGContextCmd.cpp
+++ b/src/mayaMVG/maya/context/MVGContextCmd.cpp
@@ -1,13 +1,16 @@
-#include "mayaMVG/maya/context/MVGContextCmd.hpp"
-#include "mayaMVG/maya/context/MVGContext.hpp"
+#include "MVGContextCmd.hpp"
+#include "MVGContext.hpp"
+
 #include "mayaMVG/core/MVGMesh.hpp"
 #include "mayaMVG/maya/context/MVGCreateManipulator.hpp"
 #include "mayaMVG/maya/context/MVGMoveManipulator.hpp"
 #include "mayaMVG/maya/context/MVGLocatorManipulator.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
 #include "mayaMVG/core/MVGLog.hpp"
+
 #include <maya/MPxManipulatorNode.h>
 #include <maya/MUserEventMessage.h>
+
 
 namespace
 { // empty namespace

--- a/src/mayaMVG/maya/context/MVGCreateManipulatorDrawOverride.cpp
+++ b/src/mayaMVG/maya/context/MVGCreateManipulatorDrawOverride.cpp
@@ -1,13 +1,15 @@
-#include "mayaMVG/maya/context/MVGCreateManipulatorDrawOverride.hpp"
+#include "mayaMVG/core/MVGLog.hpp"
 #include "mayaMVG/maya/context/MVGCreateManipulator.hpp"
+#include "mayaMVG/maya/context/MVGCreateManipulatorDrawOverride.hpp"
 #include "mayaMVG/maya/context/MVGDrawUtil.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
-#include "mayaMVG/core/MVGLog.hpp"
+
 #include <maya/MHWGeometryUtilities.h>
 #include <maya/MDrawContext.h>
 #include <maya/MDataHandle.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MViewport2Renderer.h>
+
 
 namespace mayaMVG
 {

--- a/src/mayaMVG/maya/context/MVGManipulator.hpp
+++ b/src/mayaMVG/maya/context/MVGManipulator.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "mayaMVG/core/MVGGeometryUtil.hpp"
+#include "mayaMVG/core/MVGPointCloudItem.hpp"
 #include "mayaMVG/maya/context/MVGManipulatorCache.hpp"
 #include "mayaMVG/maya/context/MVGContext.hpp"
-#include "mayaMVG/core/MVGPointCloudItem.hpp"
 #include "mayaMVG/maya/cmd/MVGEditCmd.hpp"
-#include "mayaMVG/core/MVGGeometryUtil.hpp"
+
 #include <maya/MPxManipulatorNode.h>
+
 
 namespace mayaMVG
 {

--- a/src/mayaMVG/maya/context/MVGManipulatorCache.cpp
+++ b/src/mayaMVG/maya/context/MVGManipulatorCache.cpp
@@ -1,10 +1,12 @@
-#include "mayaMVG/maya/context/MVGManipulatorCache.hpp"
-#include "mayaMVG/maya/MVGMayaUtil.hpp"
 #include "mayaMVG/core/MVGGeometryUtil.hpp"
 #include "mayaMVG/core/MVGMesh.hpp"
 #include "mayaMVG/core/MVGLog.hpp"
+#include "mayaMVG/maya/context/MVGManipulatorCache.hpp"
+#include "mayaMVG/maya/MVGMayaUtil.hpp"
+
 #include <maya/MItMeshVertex.h>
 #include <maya/MItMeshEdge.h>
+
 #include <list>
 
 namespace mayaMVG

--- a/src/mayaMVG/maya/context/MVGMoveManipulatorDrawOverride.cpp
+++ b/src/mayaMVG/maya/context/MVGMoveManipulatorDrawOverride.cpp
@@ -3,6 +3,7 @@
 #include "mayaMVG/maya/context/MVGDrawUtil.hpp"
 #include "mayaMVG/maya/MVGMayaUtil.hpp"
 #include "mayaMVG/core/MVGLog.hpp"
+
 #include <maya/MHWGeometryUtilities.h>
 #include <maya/MDrawContext.h>
 #include <maya/MDataHandle.h>

--- a/src/mayaMVG/qt/MVGQt.hpp
+++ b/src/mayaMVG/qt/MVGQt.hpp
@@ -1,3 +1,8 @@
+// /!\ Include this file instead of QtCore / QtGui
+
+// X11 defines CamelCase macros that clash with Qt.
+// To avoid include-order based issues, we undefine those problematic names.
+
 #if defined(LINUX)
 #if defined(None)
 #undef None


### PR DESCRIPTION
- Added flag std=c++11
  - Requires GCC > 4.7
  - Breaks compatibility with Maya < 2016
- Removed OpenMVG as a subrepo; is now an external dependency
