### PR TITLE
Remove AliceVision submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/aliceVision"]
-	path = src/aliceVision
-	url = http://github.com/alicevision/AliceVision.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,11 +12,11 @@ set(PLUGIN_VERSION_MINOR 0)
 #
 # Compiler settings
 #
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11")
-    set(CMAKE_CXX_COMPILER g++)
-    set(CMAKE_C_COMPILER gcc)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 #


### PR DESCRIPTION
MeshrooMaya is meant to be built with AliceVision as an external library.
