### PR TITLE
Update ABC load with new structure

### DIFF
--- a/src/meshroomMaya/core/MVGCamera.cpp
+++ b/src/meshroomMaya/core/MVGCamera.cpp
@@ -108,7 +108,7 @@ bool MVGCamera::isValid() const
     return true;
 }
 
-MVGCamera MVGCamera::create(MDagPath& cameraDagPath, std::map<int, MIntArray>& itemsPerCamera)
+MVGCamera MVGCamera::create(MDagPath& cameraDagPath, const std::map<int, MIntArray>& itemsPerCamera)
 {
     MStatus status;
 
@@ -140,7 +140,17 @@ MVGCamera MVGCamera::create(MDagPath& cameraDagPath, std::map<int, MIntArray>& i
     dagModifier.doIt();
 
     // Set MVG attributes
-    MVGMayaUtil::setIntArrayAttribute(cameraNode, MVGCamera::_MVG_ITEMS, itemsPerCamera[viewID]);
+    if(itemsPerCamera.find(viewID) != itemsPerCamera.end())
+    {
+        MVGMayaUtil::setIntArrayAttribute(cameraNode, MVGCamera::_MVG_ITEMS, itemsPerCamera.at(viewID));
+    }
+    else
+    {
+        // No visibility information
+        LOG_INFO("MVGCamera: viewID=" << viewID << " is NOT in the itemsPerCamera, so we initialize it to an empty array.")
+        MIntArray empyArray;
+        MVGMayaUtil::setIntArrayAttribute(cameraNode, MVGCamera::_MVG_ITEMS, empyArray);
+    }
 
     // create, reparent & connect image plane
     MString cmd;

--- a/src/meshroomMaya/core/MVGCamera.hpp
+++ b/src/meshroomMaya/core/MVGCamera.hpp
@@ -31,7 +31,7 @@ public:
     virtual bool isValid() const;
 
 public:
-    static MVGCamera create(MDagPath& cameraDagPath, std::map<int, MIntArray>& itemsPerCamera);
+    static MVGCamera create(MDagPath& cameraDagPath, const std::map<int, MIntArray>& itemsPerCamera);
     static std::vector<MVGCamera> getCameras();
 
 public:

--- a/src/meshroomMaya/maya/scripts/meshroomMaya/camera.py
+++ b/src/meshroomMaya/maya/scripts/meshroomMaya/camera.py
@@ -26,6 +26,8 @@ def setImagesPaths(abcFilePath, imageAttribute, imageSourceAttribute, thumbnailA
   for c in cameraList:
     if not cmds.attributeQuery(imageAttribute, node=c, exists=True):
       continue
+    if not cmds.attributeQuery(imageSourceAttribute, node=c, exists=True):
+      continue
     originalImagePath = cmds.getAttr(c+'.'+imageAttribute)
     cmds.setAttr(c+'.'+imageSourceAttribute, originalImagePath, type="string")
     basename = os.path.basename(originalImagePath)

--- a/src/meshroomMaya/qt/MVGProjectWrapper.cpp
+++ b/src/meshroomMaya/qt/MVGProjectWrapper.cpp
@@ -529,7 +529,7 @@ void MVGProjectWrapper::loadABC(const QString& abcFilePath)
         }
         else
         {
-            LOG_WARNING("Valid file: mvg_visibilitySize is coherent with mvg_visibilityIds."
+            LOG_INFO("Valid file: mvg_visibilitySize is coherent with mvg_visibilityIds."
                       "(mvg_visibilitySize length= " + std::to_string(visibilitySizeArray.length()) +
                       ", mvg_visibilitySize total= " + std::to_string(fullNbVisibilities) +
                       ", mvg_visibilityIds size= " + std::to_string(visibilitiesArray.length()) +


### PR DESCRIPTION
Support new ABC structure with `mvg_visibilityViewId` instead of previous `mvg_visibilityIds`.

- [x] Keep compatibility with previous file format:
 - `mvg_visibilityIds`: the old way to store visibilities with `[<viewID,
featId>]` in a flat list.
 - `mvg_visibilityViewId`: the new way with only the viewIDs

- [x] avoid error with unreconstructed cameras

